### PR TITLE
Support OpLogConsensus

### DIFF
--- a/actor_test.go
+++ b/actor_test.go
@@ -42,7 +42,7 @@ func TestSetState(t *testing.T) {
 	actor1 := NewActor(raft1)
 	actor2 := NewActor(raft2)
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(3 * time.Second)
 
 	if !actor1.IsLeader() && !actor2.IsLeader() {
 		t.Fatal("raft failed to declare a leader")

--- a/actor_test.go
+++ b/actor_test.go
@@ -25,13 +25,13 @@ func TestSetState(t *testing.T) {
 	peers1 := []*Peer{peer2}
 	peers2 := []*Peer{peer1}
 
-	raft1, _, tr1, err := makeTestingRaft(peer1, peers1)
+	raft1, _, tr1, err := makeTestingRaft(peer1, peers1, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer raft1.Shutdown()
 	defer tr1.Close()
-	raft2, _, tr2, err := makeTestingRaft(peer2, peers2)
+	raft2, _, tr2, err := makeTestingRaft(peer2, peers2, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/codec.go
+++ b/codec.go
@@ -35,26 +35,6 @@ func decodeState(bs []byte, state *consensus.State) error {
 	return nil
 }
 
-// Returns a new state which is a copy of the given one.
-// In order to copy it it serializes and deserializes it into a new
-// variable.
-func dupState(state consensus.State) (consensus.State, error) {
-	newState := state
-
-	// We encode and redecode on the new object
-	bs, err := encodeState(state)
-	if err != nil {
-		return nil, err
-	}
-
-	err = decodeState(bs, &newState)
-	if err != nil {
-		return nil, err
-	}
-
-	return newState, nil
-}
-
 // encodeOp serializes an op
 func encodeOp(op consensus.Op) ([]byte, error) {
 	var buf []byte

--- a/codec.go
+++ b/codec.go
@@ -1,0 +1,87 @@
+package libp2praft
+
+import (
+	consensus "github.com/libp2p/go-libp2p-consensus"
+	"github.com/ugorji/go/codec"
+)
+
+// encodeState serializes a state
+func encodeState(state consensus.State) ([]byte, error) {
+	var buf []byte
+	enc := codec.NewEncoderBytes(&buf, &codec.MsgpackHandle{})
+	if err := enc.Encode(state); err != nil {
+		return nil, err
+	}
+	// enc := msgpack.Multicodec().NewEncoder(buffer)
+	// if err := enc.Encode(state); err != nil {
+	// 	return nil, err
+	// }
+	return buf, nil
+}
+
+// decodeState deserializes a state
+func decodeState(bs []byte, state *consensus.State) error {
+	dec := codec.NewDecoderBytes(bs, &codec.MsgpackHandle{})
+
+	if err := dec.Decode(state); err != nil {
+		return err
+	}
+
+	// buffer := bytes.NewBuffer(bs)
+	// dec := msgpack.MultiCodec().NewDecoder(buffer)
+	// if err := dec.Decode(state); err != nil {
+	// 	return err
+	// }
+	return nil
+}
+
+// Returns a new state which is a copy of the given one.
+// In order to copy it it serializes and deserializes it into a new
+// variable.
+func dupState(state consensus.State) (consensus.State, error) {
+	newState := state
+
+	// We encode and redecode on the new object
+	bs, err := encodeState(state)
+	if err != nil {
+		return nil, err
+	}
+
+	err = decodeState(bs, &newState)
+	if err != nil {
+		return nil, err
+	}
+
+	return newState, nil
+}
+
+// encodeOp serializes an op
+func encodeOp(op consensus.Op) ([]byte, error) {
+	var buf []byte
+	enc := codec.NewEncoderBytes(&buf, &codec.MsgpackHandle{})
+	if err := enc.Encode(op); err != nil {
+		return nil, err
+	}
+
+	// enc := msgpack.Multicodec().NewEncoder(buffer)
+	// if err := enc.Encode(state); err != nil {
+	// 	return nil, err
+	// }
+	return buf, nil
+}
+
+// decodeOp deserializes a op
+func decodeOp(bs []byte, op *consensus.Op) error {
+	dec := codec.NewDecoderBytes(bs, &codec.MsgpackHandle{})
+
+	if err := dec.Decode(op); err != nil {
+		return err
+	}
+
+	// buffer := bytes.NewBuffer(bs)
+	// dec := msgpack.MultiCodec().NewDecoder(buffer)
+	// if err := dec.Decode(state); err != nil {
+	// 	return err
+	// }
+	return nil
+}

--- a/codec.go
+++ b/codec.go
@@ -2,6 +2,7 @@ package libp2praft
 
 import (
 	consensus "github.com/libp2p/go-libp2p-consensus"
+
 	"github.com/ugorji/go/codec"
 )
 
@@ -21,7 +22,9 @@ func encodeState(state consensus.State) ([]byte, error) {
 
 // decodeState deserializes a state
 func decodeState(bs []byte, state *consensus.State) error {
-	dec := codec.NewDecoderBytes(bs, &codec.MsgpackHandle{})
+	h := codec.MsgpackHandle{}
+	h.ErrorIfNoField = true
+	dec := codec.NewDecoderBytes(bs, &h)
 
 	if err := dec.Decode(state); err != nil {
 		return err
@@ -52,7 +55,10 @@ func encodeOp(op consensus.Op) ([]byte, error) {
 
 // decodeOp deserializes a op
 func decodeOp(bs []byte, op *consensus.Op) error {
-	dec := codec.NewDecoderBytes(bs, &codec.MsgpackHandle{})
+	h := codec.MsgpackHandle{}
+	// Important, allows to handle rollbacks
+	h.ErrorIfNoField = true
+	dec := codec.NewDecoderBytes(bs, &h)
 
 	if err := dec.Decode(op); err != nil {
 		return err

--- a/consensus.go
+++ b/consensus.go
@@ -6,11 +6,31 @@ import (
 	consensus "github.com/libp2p/go-libp2p-consensus"
 )
 
-// Consensus implements both the libp2p-consensus interface and the
-// hashicorp/raft FSM interface.
+// Consensus implements both the go-libp2p-consensus Consensus
+// and the OpLogConsensus interfaces. The Consensus interface can be
+// expressed as a particular case of a distributed OpLog, where every
+// operation is the state itself. Therefore, it is natural and cheap
+// to implement both in the same place.
+//
+// Furthermore, the Consensus type implements the Hashicorp
+// Raft FSM interface. It should be used to initialize Raft, which
+// can be later used as an Actor.
 type Consensus struct {
-	fsm   // A consensus is a FSM in the end, in hashicorp/raft sense
+	fsm
 	actor consensus.Actor
+}
+
+// A Consensus is a particular case of OpLogConsensus where the Operation
+// is itself the state and every new operation just replaces the previous
+// state. For this case, we use an operation which tracks the state itself.
+type consensusOp struct {
+	State consensus.State
+}
+
+// ApplyTo just returns the state in the operation and discards the
+// "old" one.
+func (cop consensusOp) ApplyTo(st consensus.State) (consensus.State, error) {
+	return cop.State, nil
 }
 
 // NewConsensus returns a new consensus. Because the State
@@ -19,8 +39,18 @@ type Consensus struct {
 // GetCurrentState() will return an error until a state is agreed upon. Only
 // states submitted via CommitState() are agreed upon.
 func NewConsensus(state consensus.State) *Consensus {
+	return NewOpLog(state, consensusOp{State: state})
+}
+
+// NewOpLog returns a new OpLog. Because the State and the Ops
+// are generic, and we know nothing about them, they need to
+// be provided in order to initialize internal structures with the
+// right types. Both the state and the op are not used nor agreed upon.
+// Only ops commited via CommitOp change the state of the system.
+func NewOpLog(state consensus.State, op consensus.Op) *Consensus {
 	con := new(Consensus)
 	con.state = state
+	con.op = op
 	con.valid = false
 	con.subscriberCh = nil
 	return con
@@ -33,7 +63,22 @@ func (c *Consensus) SetActor(actor consensus.Actor) {
 
 // GetCurrentState returns the upon-agreed state of the system.
 func (c *Consensus) GetCurrentState() (consensus.State, error) {
-	return c.State()
+	return c.GetLogHead()
+}
+
+func (opLog *Consensus) CommitOp(op consensus.Op) (consensus.State, error) {
+	if opLog.actor == nil {
+		return nil, errors.New("no actor set to commit the new state")
+	}
+	newSt, err := opLog.actor.SetState(op)
+	if err != nil {
+		return nil, err
+	}
+	return newSt, nil
+}
+
+func (opLog *Consensus) GetLogHead() (consensus.State, error) {
+	return opLog.State()
 }
 
 // CommitState pushes a new state to the system and returns
@@ -42,28 +87,9 @@ func (c *Consensus) GetCurrentState() (consensus.State, error) {
 //
 // Note that only the Raft leader can commit a state.
 func (c *Consensus) CommitState(state consensus.State) (consensus.State, error) {
-	if c.actor == nil {
-		return nil, errors.New("no actor set to commit the new state")
-	}
-	return c.actor.SetState(state)
+	return c.CommitOp(consensusOp{state})
 }
 
-// Subscribe returns a channel on which every new state is sent.
-func (c *Consensus) Subscribe() <-chan consensus.State {
-	c.chMux.Lock()
-	defer c.chMux.Unlock()
-	if c.subscriberCh == nil {
-		c.subscriberCh = make(chan consensus.State, MaxSubscriberCh)
-	}
-	return c.subscriberCh
-}
-
-// Unsubscribe closes the channel returned upon Subscribe() (if any).
-func (c *Consensus) Unsubscribe() {
-	c.chMux.Lock()
-	defer c.chMux.Unlock()
-	if c.subscriberCh != nil {
-		close(c.subscriberCh)
-		c.subscriberCh = nil
-	}
+func (opLog *Consensus) Rollback(state consensus.State) error {
+	return errors.New("Not implemented")
 }

--- a/consensus.go
+++ b/consensus.go
@@ -7,10 +7,10 @@ import (
 )
 
 // Consensus implements both the go-libp2p-consensus Consensus
-// and the OpLogConsensus interfaces. The Consensus interface can be
-// expressed as a particular case of a distributed OpLog, where every
-// operation is the state itself. Therefore, it is natural and cheap
-// to implement both in the same place.
+// and the OpLogConsensus interfaces. This is because the Consensus
+// interface is just a particular case of the OpLog interface,
+// where the operation applied holds the new version of the state
+// and replaces the current one with it.
 //
 // Furthermore, the Consensus type implements the Hashicorp
 // Raft FSM interface. It should be used to initialize Raft, which

--- a/consensus_test.go
+++ b/consensus_test.go
@@ -165,6 +165,7 @@ func TestOpLog(t *testing.T) {
 	}
 
 	// Only leader will succeed
+	t.Log("testing CommitOp")
 	testCommitOps(opLog1)
 	testCommitOps(opLog2)
 
@@ -190,5 +191,35 @@ func TestOpLog(t *testing.T) {
 	t.Log(newSt2.Msg)
 	if newSt2.Msg != "I have appended this sentence to the state Msg." {
 		t.Error("Log head is not the result of applying the operations")
+	}
+
+	// Test a ROLLBACK now
+	// Only the leader will succeed
+	t.Log("testing Rollback")
+	opLog1.Rollback(raftState{"Good as new"})
+	opLog2.Rollback(raftState{"Good as new"})
+
+	time.Sleep(1 * time.Second)
+
+	logHead1, err = opLog1.GetLogHead()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logHead2, err = opLog2.GetLogHead()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newSt1 = logHead1.(raftState)
+	t.Log(newSt1.Msg)
+	if newSt1.Msg != "Good as new" {
+		t.Error("Log head is not the result of a rollback")
+	}
+
+	newSt2 = logHead2.(raftState)
+	t.Log(newSt2.Msg)
+	if newSt2.Msg != "Good as new" {
+		t.Error("Log head is not the result of a rollback")
 	}
 }

--- a/consensus_test.go
+++ b/consensus_test.go
@@ -170,8 +170,15 @@ func TestOpLog(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	logHead1, _ := opLog1.GetLogHead()
-	logHead2, _ := opLog2.GetLogHead()
+	logHead1, err := opLog1.GetLogHead()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logHead2, err := opLog2.GetLogHead()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	newSt1 := logHead1.(raftState)
 	t.Log(newSt1.Msg)

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -1,6 +1,10 @@
 package libp2praft
 
-import "testing"
+import (
+	"testing"
+
+	consensus "github.com/libp2p/go-libp2p-consensus"
+)
 
 // Lets assume this would be our state
 type testState struct {
@@ -13,8 +17,7 @@ type simple struct {
 	D int
 }
 
-// This should cover encode/decode too
-func TestDupState(t *testing.T) {
+func TestCodecs(t *testing.T) {
 	st := testState{
 		A: 5,
 		B: "hola",
@@ -23,7 +26,14 @@ func TestDupState(t *testing.T) {
 		},
 	}
 
-	stmp, err := dupState(st)
+	bytes, err := encodeState(st)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stmp := consensus.State(testState{})
+
+	err = decodeState(bytes, &stmp)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/raft.go
+++ b/raft.go
@@ -21,13 +21,14 @@
 // how these instances look like.
 //
 // Any consensus.State or consensus.Op is expected any relevant
-// fields as public fields. Private fields are not serialized,
+// fields as exported fields. Unexported fields are not serialized,
 // they are not transmitted, not received and deserialized
-// in other nodes. Private fields stay at the value provided by
+// in other nodes. Unexported fields stay at the value provided by
 // the state and op initializers in the NewConsensus() or NewOpLog().
 // This includes the fields from children structs. Therefore,
 // it is recommended to simplify user defined types like consensus.Op
-// and consensus.State as much as possible.
+// and consensus.State as much as possible and declare all
+// relevant fields as exported.
 //
 // A consensus.Op ApplyTo() operation may return an error. This
 // means that, while the operation is agreed-upon, the resulting

--- a/raft.go
+++ b/raft.go
@@ -1,5 +1,46 @@
-// Package libp2praft implements a go-libp2p-consensus interface wrapping hashicorp/raft
-// implementation and providing a libp2p network transport for it.
+// Package libp2praft implements the go-libp2p-consensus interface
+// wrapping the github.com/hashicorp/raft implementation, providing
+// a custom generic FSM to handle states and generic operations and
+// giving the user a go-libp2p-based network transport to use.
+//
+// The main entry points to this library are the Consensus and Actor
+// types. Usually, the first step is to create the Consensus, then
+// use the underlying FSM to initialize a Raft instance, along with
+// the Libp2pTransport. With a Raft instance, an Actor can be
+// created and then used with Consensus.SetActor(). From this point,
+// the consensus system is ready to use.
+//
+// It is IMPORTANT to make a few notes about the types of objects
+// to be used as consensus.State and consensus.Op, since the
+// go-libp2p-consensus interface does not make many assumptions
+// about them (consensus.State being an empty interface).
+//
+// In order for go-libp2p-raft to work properly, instances of
+// consensus.State and consensus.Op are going to be serialized
+// and transmitted between nodes. This imposes limitations on
+// how these instances look like.
+//
+// Any consensus.State or consensus.Op is expected any relevant
+// fields as public fields. Private fields are not serialized,
+// they are not transmitted, not received and deserialized
+// in other nodes. Private fields stay at the value provided by
+// the state and op initializers in the NewConsensus() or NewOpLog().
+// This includes the fields from children structs. Therefore,
+// it is recommended to simplify user defined types like consensus.Op
+// and consensus.State as much as possible.
+//
+// A consensus.Op ApplyTo() operation may return an error. This
+// means that, while the operation is agreed-upon, the resulting
+// state cannot be produced. This marks the state in that node
+// as dirty but does not removes the operation itself.
+// See CommitOp() for more details.
+//
+// Using pointer types for consensus.Op and consensus.State implies
+// that consensus operations will return pointers. Modifying
+// a consensus.State defined as pointer, may affect the internal
+// state of the Raft FSM. Therefore, it is recommended to not use
+// Ops and States as pointers, and let Go perform and return
+// independent copies.
 package libp2praft
 
 import (

--- a/transport_test.go
+++ b/transport_test.go
@@ -17,11 +17,11 @@ func TestTransportSnapshots(t *testing.T) {
 	peers1 := []*Peer{peer2}
 	peers2 := []*Peer{peer1}
 
-	raft1, c1, tr1, err := makeTestingRaft(peer1, peers1)
+	raft1, c1, tr1, err := makeTestingRaft(peer1, peers1, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	raft2, c2, tr2, err := makeTestingRaft(peer2, peers2)
+	raft2, c2, tr2, err := makeTestingRaft(peer2, peers2, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func TestTransportSnapshots(t *testing.T) {
 	tr2.Close()
 
 	t.Log("Forcing Raft1 to restore the snapshot")
-	raft1, c1, tr1, err = makeTestingRaft(peer1, peers1)
+	raft1, c1, tr1, err = makeTestingRaft(peer1, peers1, nil)
 	if err != nil {
 		t.Fatalf("raft1: %s", err)
 	}
@@ -78,7 +78,7 @@ func TestTransportSnapshots(t *testing.T) {
 	raftTmpFolder = "testing_tmp2"
 	defer os.RemoveAll("testing_tmp2")
 
-	raft2, c2, tr2, err = makeTestingRaft(peer2, peers2)
+	raft2, c2, tr2, err = makeTestingRaft(peer2, peers2, nil)
 	if err != nil {
 		t.Fatalf("raft2: %s", err)
 	}
@@ -102,12 +102,12 @@ func TestNewLibp2pTransportWithHost(t *testing.T) {
 	peers1 := []*Peer{peer2}
 	peers2 := []*Peer{peer1}
 
-	raft1, _, tr1, err := makeTestingRaft(peer1, peers1)
+	raft1, _, tr1, err := makeTestingRaft(peer1, peers1, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer tr1.Close()
-	raft2, _, tr2, err := makeTestingRaft(peer2, peers2)
+	raft2, _, tr2, err := makeTestingRaft(peer2, peers2, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Seems implementing OpLogConsensus the way I wanted might just work without further changes to the consensus interface.

It is clear to me now that a state-based Consensus is just a particular case of an OpLogConsensus. As such, go-libp2p-raft.Consensus now implements both interfaces. The Raft FSM now always applies an Op to the existing State and the Raft log is made of Ops and not of States. For the Consensus case, we use an special Op which holds the full state.

Tests have not been touched and they are green. Need to are a couple of more tests to verify the OpLogConsensus endpoints are doing what they should.

Related issue #1 .