### PR TITLE
Implement raft.FSM separately from Consensus.

### DIFF
--- a/consensus.go
+++ b/consensus.go
@@ -109,7 +109,7 @@ func (opLog *Consensus) CommitOp(op consensus.Op) (consensus.State, error) {
 // cannot be ensured to be that on which the rest of the system has
 // agreed-upon.
 func (opLog *Consensus) GetLogHead() (consensus.State, error) {
-	return opLog.fsm.State()
+	return opLog.fsm.getState()
 }
 
 // CommitState pushes a new state to the system and returns

--- a/consensus.go
+++ b/consensus.go
@@ -11,12 +11,8 @@ import (
 // interface is just a particular case of the OpLog interface,
 // where the operation applied holds the new version of the state
 // and replaces the current one with it.
-//
-// Furthermore, the Consensus type implements the Hashicorp
-// Raft FSM interface. It should be used to initialize Raft, which
-// can be later used as an Actor.
 type Consensus struct {
-	fsm
+	fsm   *FSM
 	actor consensus.Actor
 }
 
@@ -55,13 +51,22 @@ func NewConsensus(state consensus.State) *Consensus {
 // (with Op.ApplyTo()).
 // See the notes in CommitOp() for more information.
 func NewOpLog(state consensus.State, op consensus.Op) *Consensus {
-	con := new(Consensus)
-	con.state = state
-	con.op = op
-	con.initialized = false
-	con.inconsistent = false
-	con.subscriberCh = nil
-	return con
+	return &Consensus{
+		fsm: &FSM{
+			state:        state,
+			op:           op,
+			initialized:  false,
+			inconsistent: false,
+			subscriberCh: nil,
+		},
+		actor: nil,
+	}
+}
+
+// FSM returns the raft.FSM implementation provided by go-libp2p-raft. It is
+// necessary to initialize raft with this FSM.
+func (c *Consensus) FSM() *FSM {
+	return c.fsm
 }
 
 // SetActor changes the actor in charge of submitting new states to the system.
@@ -104,7 +109,7 @@ func (opLog *Consensus) CommitOp(op consensus.Op) (consensus.State, error) {
 // cannot be ensured to be that on which the rest of the system has
 // agreed-upon.
 func (opLog *Consensus) GetLogHead() (consensus.State, error) {
-	return opLog.State()
+	return opLog.fsm.State()
 }
 
 // CommitState pushes a new state to the system and returns
@@ -123,4 +128,14 @@ func (c *Consensus) CommitState(state consensus.State) (consensus.State, error) 
 func (opLog *Consensus) Rollback(state consensus.State) error {
 	_, err := opLog.CommitState(state)
 	return err
+}
+
+// subscribe returns a channel on which every new state is sent.
+func (c *Consensus) Subscribe() <-chan consensus.State {
+	return c.fsm.subscribe()
+}
+
+// unsubscribe closes the channel returned upon Subscribe() (if any).
+func (c *Consensus) Unsubscribe() {
+	c.fsm.unsubscribe()
 }

--- a/consensus_test.go
+++ b/consensus_test.go
@@ -64,7 +64,7 @@ func TestSubscribe(t *testing.T) {
 	c1.Subscribe() // cover multiple calls to subscribe
 	c2.Subscribe()
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(3 * time.Second)
 
 	if !actor1.IsLeader() && !actor2.IsLeader() {
 		t.Fatal("raft failed to declare a leader")

--- a/fsm.go
+++ b/fsm.go
@@ -137,8 +137,8 @@ func (fsm *FSM) unsubscribe() {
 	}
 }
 
-// State returns the current state as agreed by the cluster
-func (fsm *FSM) State() (consensus.State, error) {
+// getState returns the current state as agreed by the cluster
+func (fsm *FSM) getState() (consensus.State, error) {
 	fsm.mux.Lock()
 	defer fsm.mux.Unlock()
 	if !fsm.initialized {

--- a/raft.go
+++ b/raft.go
@@ -5,7 +5,7 @@
 //
 // The main entry points to this library are the Consensus and Actor
 // types. Usually, the first step is to create the Consensus, then
-// use the underlying FSM to initialize a Raft instance, along with
+// use the *Consensus.FSM() object to initialize a Raft instance, along with
 // the Libp2pTransport. With a Raft instance, an Actor can be
 // created and then used with Consensus.SetActor(). From this point,
 // the consensus system is ready to use.

--- a/raft_test.go
+++ b/raft_test.go
@@ -63,7 +63,7 @@ func makeTestingRaft(node *Peer, peers []*Peer, op consensus.Op) (*raft.Raft, *C
 
 	// Raft node creation: we use our consensus objects directly as they
 	// implement Raft FSM interface.
-	raft, err := raft.NewRaft(config, consensus, logStore, logStore, snapshots, pstore, transport)
+	raft, err := raft.NewRaft(config, consensus.FSM(), logStore, logStore, snapshots, pstore, transport)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -165,15 +165,15 @@ func Example_consensus() {
 
 	// Raft node creation: we use our consensus objects directly as they
 	// implement Raft FSM interface.
-	raft1, err := raft.NewRaft(config, consensus1, logStore1, logStore1, snapshots1, pstore1, transport1)
+	raft1, err := raft.NewRaft(config, consensus1.FSM(), logStore1, logStore1, snapshots1, pstore1, transport1)
 	if err != nil {
 		log.Fatal(err)
 	}
-	raft2, err := raft.NewRaft(config, consensus2, logStore2, logStore2, snapshots2, pstore2, transport2)
+	raft2, err := raft.NewRaft(config, consensus2.FSM(), logStore2, logStore2, snapshots2, pstore2, transport2)
 	if err != nil {
 		log.Fatal(err)
 	}
-	raft3, err := raft.NewRaft(config, consensus3, logStore3, logStore3, snapshots3, pstore3, transport3)
+	raft3, err := raft.NewRaft(config, consensus3.FSM(), logStore3, logStore3, snapshots3, pstore3, transport3)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Make FSM its own type. Simplifies the API of the Consensus type. Usage is clearer. Removes the temptation of using any of the FSM methods directly, as they are only for Raft.

It seemed a good idea to mix both things at the beginning (since conceptually they are the same), but from a newcomer-dev point of view it just adds lots of confusion and makes it easy to make silly mistakes like calling Apply() or State() directly.