### PR TITLE
Gx all deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+coverage.out
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: go
 go:
 - '1.7'
 install:
-- go get github.com/hashicorp/raft
-- go get github.com/ugorji/go/codec
 - go get golang.org/x/tools/cmd/cover
 - go get github.com/mattn/goveralls
 - make all

--- a/package.json
+++ b/package.json
@@ -16,6 +16,18 @@
       "hash": "QmZ88KbrvZMJpXaNwAGffswcYKz8EbeafzAFGMCA6MEZKt",
       "name": "go-libp2p-consensus",
       "version": "0.0.3"
+    },
+    {
+      "author": "hashicorp",
+      "hash": "QmcqdQoV9LnszXJoqFYXxbs4BrKTfGQqrVs6aJjZxSVurX",
+      "name": "raft",
+      "version": "2017.1.3"
+    },
+    {
+      "author": "ugorji",
+      "hash": "QmRpRGNbrm6aaU7bnt6AwcJCfyETkdJzmtBdCazMYKoMux",
+      "name": "go-codec",
+      "version": "2017.1.3"
     }
   ],
   "gxVersion": "0.9.1",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmbzCT1CwxVZ2ednptC9RavuJe7Bv8DDi2Ne89qUrA37XM",
+      "hash": "QmQHmMFyhfp2ZXnbYWqAWhEideDCNDM6hzJwqCU29Y5zV2",
       "name": "go-libp2p",
-      "version": "4.3.0"
+      "version": "4.3.1"
     },
     {
       "author": "hsanjuan",


### PR DESCRIPTION
 Sources are at:
    
      * https://github.com/hsanjuan/go-codec
      * https://github.com/hsanjuan/raft
    
    dvcsimport is set to original urls so it works like if the original were gx'ed.