### PR TITLE
Pass state object that implements marshable

### DIFF
--- a/actor_test.go
+++ b/actor_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestNewActor(t *testing.T) {
 	actor := NewActor(nil)
-	st, err := actor.SetState(raftState{"testing"})
+	st, err := actor.SetState(&raftState{"testing"})
 	if st != nil || err == nil {
 		t.Error("should fail when setting an state and raft is nil")
 	}
@@ -38,19 +38,19 @@ func TestSetState(t *testing.T) {
 	t.Log(actor2.Leader())
 
 	testLeader := func(actor *Actor) {
-		st, err := actor.SetState(raftState{"testingLeader"})
+		st, err := actor.SetState(&raftState{"testingLeader"})
 		if err != nil {
 			t.Fatal("the leader should be able to set the state")
 		}
 
-		rSt := st.(raftState)
+		rSt := st.(*raftState)
 		if rSt.Msg != "testingLeader" {
 			t.Error("the returned state is not correct")
 		}
 	}
 
 	testFollower := func(actor *Actor) {
-		st, err := actor.SetState(raftState{"testingFollower"})
+		st, err := actor.SetState(&raftState{"testingFollower"})
 		if st != nil || err == nil {
 			t.Error("the follower should not be able to set the state")
 		}

--- a/codec.go
+++ b/codec.go
@@ -34,9 +34,8 @@ func EncodeSnapshot(state consensus.State) ([]byte, error) {
 	marshable, ok := state.(MarshableState)
 	if ok {
 		return marshable.Marshal()
-	} else {
-		return encodeState(stateWrapper{state})
 	}
+	return encodeState(stateWrapper{state})
 }
 
 // DecodeSnapshot de-serializes a state encoded with EncodeSnapshot
@@ -46,9 +45,8 @@ func DecodeSnapshot(snap []byte, state consensus.State) error {
 	marshable, ok := state.(MarshableState)
 	if ok {
 		return marshable.Unmarshal(snap)
-	} else {
-		return decodeState(snap, &stateWrapper{state})
 	}
+	return decodeState(snap, &stateWrapper{state})
 }
 
 // encodeOp serializes an op

--- a/consensus.go
+++ b/consensus.go
@@ -150,12 +150,12 @@ func (opLog *Consensus) Rollback(state consensus.State) error {
 	return err
 }
 
-// subscribe returns a channel on which every new state is sent.
-func (c *Consensus) Subscribe() <-chan consensus.State {
+// Subscribe returns a channel which is notified on every state update.
+func (c *Consensus) Subscribe() <-chan struct{} {
 	return c.fsm.subscribe()
 }
 
-// unsubscribe closes the channel returned upon Subscribe() (if any).
+// Unsubscribe closes the channel returned upon Subscribe() (if any).
 func (c *Consensus) Unsubscribe() {
 	c.fsm.unsubscribe()
 }

--- a/consensus_test.go
+++ b/consensus_test.go
@@ -117,7 +117,7 @@ func TestSubscribe(t *testing.T) {
 
 	updateState := func(c *Consensus) {
 		for i := 0; i < 5; i++ {
-			c.CommitState(raftState{fmt.Sprintf("%d", i)})
+			c.CommitState(&raftState{fmt.Sprintf("%d", i)})
 		}
 	}
 
@@ -128,14 +128,9 @@ func TestSubscribe(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// Check subscriber 1 got all the updates and not more
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 5; i++ {
 		select {
-		case st := <-subscriber1:
-			newSt := st.(raftState)
-			t.Log("received state:", newSt.Msg)
-			if newSt.Msg != fmt.Sprintf("%d", i) {
-				t.Fatal("expected a different state")
-			}
+		case <-subscriber1:
 		default:
 			if i < 5 {
 				t.Fatal("expected to read something")
@@ -146,14 +141,9 @@ func TestSubscribe(t *testing.T) {
 	}
 
 	// Check subscriber 2 got all the updates and not more
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 5; i++ {
 		select {
-		case st := <-subscriber2:
-			newSt := st.(raftState)
-			t.Log("received state:", newSt.Msg)
-			if newSt.Msg != fmt.Sprintf("%d", i) {
-				t.Fatal("expected a different state")
-			}
+		case <-subscriber2:
 		default:
 			if i < 5 {
 				t.Fatal("expected to read something")
@@ -217,13 +207,13 @@ func TestOpLog(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	newSt1 := logHead1.(raftState)
+	newSt1 := logHead1.(*raftState)
 	t.Log(newSt1.Msg)
 	if newSt1.Msg != "I have appended this sentence to the state Msg." {
 		t.Error("Log head is not the result of applying the operations")
 	}
 
-	newSt2 := logHead2.(raftState)
+	newSt2 := logHead2.(*raftState)
 	t.Log(newSt2.Msg)
 	if newSt2.Msg != "I have appended this sentence to the state Msg." {
 		t.Error("Log head is not the result of applying the operations")
@@ -232,8 +222,8 @@ func TestOpLog(t *testing.T) {
 	// Test a ROLLBACK now
 	// Only the leader will succeed
 	t.Log("testing Rollback")
-	opLog1.Rollback(raftState{"Good as new"})
-	opLog2.Rollback(raftState{"Good as new"})
+	opLog1.Rollback(&raftState{"Good as new"})
+	opLog2.Rollback(&raftState{"Good as new"})
 
 	time.Sleep(1 * time.Second)
 
@@ -247,13 +237,13 @@ func TestOpLog(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	newSt1 = logHead1.(raftState)
+	newSt1 = logHead1.(*raftState)
 	t.Log(newSt1.Msg)
 	if newSt1.Msg != "Good as new" {
 		t.Error("log head is not the result of a rollback")
 	}
 
-	newSt2 = logHead2.(raftState)
+	newSt2 = logHead2.(*raftState)
 	t.Log(newSt2.Msg)
 	if newSt2.Msg != "Good as new" {
 		t.Error("log head is not the result of a rollback")
@@ -307,8 +297,8 @@ func TestBadApplyAt(t *testing.T) {
 	// Test a ROLLBACK now
 	// Only the leader will succeed
 	t.Log("testing Rollback")
-	opLog1.Rollback(raftState{"Good as new"})
-	opLog2.Rollback(raftState{"Good as new"})
+	opLog1.Rollback(&raftState{"Good as new"})
+	opLog2.Rollback(&raftState{"Good as new"})
 
 	time.Sleep(1 * time.Second)
 
@@ -322,13 +312,13 @@ func TestBadApplyAt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	newSt1 := logHead1.(raftState)
+	newSt1 := logHead1.(*raftState)
 	t.Log(newSt1.Msg)
 	if newSt1.Msg != "Good as new" {
 		t.Error("log head is not the result of a rollback")
 	}
 
-	newSt2 := logHead2.(raftState)
+	newSt2 := logHead2.(*raftState)
 	t.Log(newSt2.Msg)
 	if newSt2.Msg != "Good as new" {
 		t.Error("log head is not the result of a rollback")

--- a/fsm.go
+++ b/fsm.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/raft"
 )
 
+// MaxSubscriberCh indicates how much buffering the subscriber channel
+// has.
 var MaxSubscriberCh = 128
 
 // a concrete type to facilitate serialization etc as doing it
@@ -87,6 +89,7 @@ func (fsm *FSM) Apply(rlog *raft.Log) interface{} {
 	return fsm.stateWrap.State
 }
 
+// Snapshot encodes the current state so that we can save a snapshot.
 func (fsm *FSM) Snapshot() (raft.FSMSnapshot, error) {
 	fsm.mux.Lock()
 	defer fsm.mux.Unlock()
@@ -109,6 +112,7 @@ func (fsm *FSM) Snapshot() (raft.FSMSnapshot, error) {
 	return snap, nil
 }
 
+// Restore takes a snapshot and sets the current state from it.
 func (fsm *FSM) Restore(reader io.ReadCloser) error {
 	snapBytes, err := ioutil.ReadAll(reader)
 	if err != nil {

--- a/fsm.go
+++ b/fsm.go
@@ -100,7 +100,7 @@ func (fsm *FSM) Snapshot() (raft.FSMSnapshot, error) {
 	}
 
 	// Encode the state
-	bytes, err := EncodeSnapshot(fsm.stateWrap)
+	bytes, err := EncodeSnapshot(fsm.stateWrap.State)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func (fsm *FSM) Restore(reader io.ReadCloser) error {
 
 	fsm.mux.Lock()
 	defer fsm.mux.Unlock()
-	if err := DecodeSnapshot(snapBytes, &fsm.stateWrap); err != nil {
+	if err := DecodeSnapshot(snapBytes, fsm.stateWrap.State); err != nil {
 		logger.Errorf("error decoding snapshot: %s", err)
 		return err
 	}

--- a/raft.go
+++ b/raft.go
@@ -36,12 +36,9 @@
 // as dirty but does not removes the operation itself.
 // See CommitOp() for more details.
 //
-// Using pointer types for consensus.Op and consensus.State implies
-// that consensus operations will return pointers. Modifying
-// a consensus.State defined as pointer, may affect the internal
-// state of the Raft FSM. Therefore, it is recommended to not use
-// Ops and States as pointers, and let Go perform and return
-// independent copies.
+// The underlying state for consensus.State should be a pointer,
+// otherwise some operations won't work. Once provided, the state
+// should only be modifed by this library.
 package libp2praft
 
 import (

--- a/raft_test.go
+++ b/raft_test.go
@@ -33,8 +33,8 @@ type testOperation struct {
 }
 
 func (o testOperation) ApplyTo(s consensus.State) (consensus.State, error) {
-	raftSt := s.(raftState)
-	return raftState{Msg: raftSt.Msg + o.Append}, nil
+	raftSt := s.(*raftState)
+	return &raftState{Msg: raftSt.Msg + o.Append}, nil
 }
 
 // wait 10 seconds for a leader.
@@ -84,9 +84,9 @@ func makeTestingRaft(t *testing.T, h host.Host, pids []peer.ID, op consensus.Op)
 	// -- Create the consensus with no actor attached
 	var consensus *Consensus
 	if op != nil {
-		consensus = NewOpLog(raftState{}, op)
+		consensus = NewOpLog(&raftState{}, op)
 	} else {
-		consensus = NewConsensus(raftState{"i am not consensuated"})
+		consensus = NewConsensus(&raftState{"i am not consensuated"})
 	}
 	// --
 
@@ -207,9 +207,9 @@ func Example_consensus() {
 	// Note that state is just used for local initialization, and that,
 	// only states submitted via CommitState() alters the state of the
 	// cluster.
-	consensus1 := NewConsensus(raftState{3})
-	consensus2 := NewConsensus(raftState{3})
-	consensus3 := NewConsensus(raftState{3})
+	consensus1 := NewConsensus(&raftState{3})
+	consensus2 := NewConsensus(&raftState{3})
+	consensus3 := NewConsensus(&raftState{3})
 
 	// Create LibP2P transports Raft
 	transport1, err := NewLibp2pTransport(peer1, time.Minute)
@@ -319,7 +319,7 @@ func Example_consensus() {
 				break
 			}
 
-			newState := raftState{nUpdates * 2}
+			newState := &raftState{nUpdates * 2}
 
 			// CommitState() blocks until the state has been
 			// agreed upon by everyone
@@ -332,7 +332,7 @@ func Example_consensus() {
 				fmt.Println("agreedState is nil: commited on a non-leader?")
 				continue
 			}
-			agreedRaftState := agreedState.(raftState)
+			agreedRaftState := agreedState.(*raftState)
 			nUpdates++
 
 			if nUpdates%200 == 0 {
@@ -380,9 +380,9 @@ func Example_consensus() {
 		fmt.Println(err)
 		return
 	}
-	finalRaftState1 := finalState1.(raftState)
-	finalRaftState2 := finalState2.(raftState)
-	finalRaftState3 := finalState3.(raftState)
+	finalRaftState1 := finalState1.(*raftState)
+	finalRaftState2 := finalState2.(*raftState)
+	finalRaftState3 := finalState3.(*raftState)
 
 	fmt.Printf("Raft1 final state: %d\n", finalRaftState1.Value)
 	fmt.Printf("Raft2 final state: %d\n", finalRaftState2.Value)

--- a/transport_test.go
+++ b/transport_test.go
@@ -75,7 +75,7 @@ func TestTransportSnapshots(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	newst, err := c1.GetCurrentState()
-	st := newst.(raftState)
+	st := newst.(*raftState)
 	if st.Msg != "count: 4999" {
 		t.Error("state not restored correctly")
 		t.Error(st.Msg)


### PR DESCRIPTION
After debugging the state upgrade pull request I found that these two lines were the source of my trouble.  If just passing the stateWrap golang interface casting in Encode/DecodeSnapshot will declare that the object does not implement the marshable interface and just call encode/decode state.  I ran into another problem due to the reference of the state also not implementing marshable so I got rid of the '&' on decode.  Note decode still unmarshals into the object underneath state even without the address so this doesn't set us back.

This has been tested out on basic functionality and the state upgrade flow.  Let me know if you have any problems with this.  