### PR TITLE
Don't error on empty state

### DIFF
--- a/actor.go
+++ b/actor.go
@@ -11,7 +11,7 @@ import (
 )
 
 // SetStateTimeout specifies how long before giving up on setting a state
-var SetStateTimeout time.Duration = 1 * time.Second
+var SetStateTimeout = 1 * time.Second
 
 // Actor implements a consensus.Actor, allowing to SetState
 // in a libp2p Consensus system. In order to do this it uses hashicorp/raft

--- a/consensus.go
+++ b/consensus.go
@@ -144,11 +144,11 @@ func (c *Consensus) GetCurrentState() (consensus.State, error) {
 // Inconsistent states can be rescued using Rollback().
 // The underlying object to the returned State will be the one provided
 // during initialization.
-func (opLog *Consensus) CommitOp(op consensus.Op) (consensus.State, error) {
-	if opLog.actor == nil {
+func (c *Consensus) CommitOp(op consensus.Op) (consensus.State, error) {
+	if c.actor == nil {
 		return nil, errors.New("no actor set to commit the new state")
 	}
-	newSt, err := opLog.actor.SetState(op)
+	newSt, err := c.actor.SetState(op)
 	if err != nil {
 		return nil, err
 	}
@@ -159,8 +159,8 @@ func (opLog *Consensus) CommitOp(op consensus.Op) (consensus.State, error) {
 // return an error when no state has been agreed upon or when the state
 // cannot be ensured to be that on which the rest of the system has
 // agreed-upon.
-func (opLog *Consensus) GetLogHead() (consensus.State, error) {
-	return opLog.fsm.getState()
+func (c *Consensus) GetLogHead() (consensus.State, error) {
+	return c.fsm.getState()
 }
 
 // CommitState pushes a new state to the system and returns
@@ -179,8 +179,8 @@ func (c *Consensus) CommitState(state consensus.State) (consensus.State, error) 
 //
 // Note that the full state needs to be loaded onto memory (like an operation)
 // so this is potentially dangerous with very large states.
-func (opLog *Consensus) Rollback(state consensus.State) error {
-	_, err := opLog.CommitState(state)
+func (c *Consensus) Rollback(state consensus.State) error {
+	_, err := c.CommitState(state)
 	return err
 }
 

--- a/consensus_test.go
+++ b/consensus_test.go
@@ -51,8 +51,8 @@ func TestNewConsensus(t *testing.T) {
 	con := NewConsensus(state)
 
 	st, err := con.GetCurrentState()
-	if st != nil || err == nil {
-		t.Error("GetCurrentState() should error if state is not valid")
+	if err != nil {
+		t.Error("GetCurrentState() should not error if state is empty")
 	}
 
 	st, err = con.CommitState(state)

--- a/fsm.go
+++ b/fsm.go
@@ -14,10 +14,6 @@ import (
 // has.
 var MaxSubscriberCh = 128
 
-// ErrNoState is returned when no state has been agreed upon by the consensus
-// protocol
-var ErrNoState = errors.New("no state has been agreed upon yet")
-
 // FSM implements a minimal raft.FSM that holds a generic consensus.State
 // and applies generic Ops to it. The state can be serialized/deserialized,
 // snappshotted and restored.
@@ -138,9 +134,6 @@ func (fsm *FSM) unsubscribe() {
 func (fsm *FSM) getState() (consensus.State, error) {
 	fsm.mux.Lock()
 	defer fsm.mux.Unlock()
-	if !fsm.initialized {
-		return nil, ErrNoState
-	}
 	if fsm.inconsistent {
 		return nil, errors.New("the state on this node is not consistent")
 	}

--- a/raft_test.go
+++ b/raft_test.go
@@ -47,7 +47,9 @@ func waitForLeader(t *testing.T, r *raft.Raft) {
 	// setting the Leader and only when the RaftState has changed.
 	// Therefore, we need a ticker.
 
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
 	ticker := time.NewTicker(time.Second / 2)
 	defer ticker.Stop()
 	for {
@@ -228,7 +230,7 @@ func Example_consensus() {
 			Address:  raft.ServerAddress(h.ID().Pretty()),
 		})
 	}
-	serversCfg := raft.Configuration{servers}
+	serversCfg := raft.Configuration{Servers: servers}
 
 	// Create Raft Configs. The Local ID is the PeerOID
 	config1 := raft.DefaultConfig()


### PR DESCRIPTION
and some linting modifications

Getting a state even if it is empty is helpful, when passed by reference. Though it is empty at the moment, it could have information later, which we could retrieve. 