### PR TITLE
Fixes on ServerAddr() method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 language: go
 
 go:
-  - 1.12.x
+  - 1.13.x
 
 env:
   global:

--- a/go.mod
+++ b/go.mod
@@ -10,3 +10,5 @@ require (
 	github.com/libp2p/go-libp2p-peerstore v0.1.3
 	github.com/ugorji/go/codec v1.1.7
 )
+
+go 1.13

--- a/raft_test.go
+++ b/raft_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"os"
 	"testing"
 	"time"
 
@@ -246,22 +245,10 @@ func Example_consensus() {
 	config3.Logger = nil
 	config3.LocalID = raft.ServerID(peer3.ID().Pretty())
 
-	// Create snapshotStores
-	snapshots1, err := raft.NewFileSnapshotStore("example_data1", 3, nil)
-	if err != nil {
-		log.Fatal("file snapshot store:", err)
-	}
-	snapshots2, err := raft.NewFileSnapshotStore("example_data2", 3, nil)
-	if err != nil {
-		log.Fatal("file snapshot store:", err)
-	}
-	snapshots3, err := raft.NewFileSnapshotStore("example_data3", 3, nil)
-	if err != nil {
-		log.Fatal("file snapshot store:", err)
-	}
-	defer os.RemoveAll("example_data1")
-	defer os.RemoveAll("example_data2")
-	defer os.RemoveAll("example_data3")
+	// Create snapshotStores. Use FileSnapshotStore in production.
+	snapshots1 := raft.NewInmemSnapshotStore()
+	snapshots2 := raft.NewInmemSnapshotStore()
+	snapshots3 := raft.NewInmemSnapshotStore()
 
 	// Create the InmemStores for use as log store and stable store.
 	logStore1 := raft.NewInmemStore()

--- a/transport.go
+++ b/transport.go
@@ -3,7 +3,6 @@ package libp2praft
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log"
 	"net"
 	"strings"
@@ -95,18 +94,10 @@ type addrProvider struct {
 	h host.Host
 }
 
-// ServerAddr takes a raft.ServerID and checks that it is a valid PeerID and
-// that our libp2p host has at least one address to contact it. It then returns
-// the ServerID as ServerAddress. On all other cases it will throw an error.
+// ServerAddr takes a raft.ServerID and returns it as a ServerAddress.  libp2p
+// will either know how to contact that peer ID or try to find it using the
+// configured routing mechanism.
 func (ap *addrProvider) ServerAddr(id raft.ServerID) (raft.ServerAddress, error) {
-	pid, err := peer.IDB58Decode(string(id))
-	if err != nil {
-		return "", fmt.Errorf("bad peer ID: %s", id)
-	}
-	addrs := ap.h.Peerstore().Addrs(pid)
-	if len(addrs) == 0 {
-		return "", fmt.Errorf("libp2p host does not know peer %s", id)
-	}
 	return raft.ServerAddress(id), nil
 
 }


### PR DESCRIPTION
It only causes log spamming. Raft even ignores any errors.