### PR TITLE
add support for hclogger 1.5.0+

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/libp2p/go-libp2p-raft
 
 require (
-	github.com/hashicorp/go-hclog v1.3.0
+	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/raft v1.3.10
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/libp2p/go-libp2p v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,10 @@ github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-hclog v0.9.1/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v1.3.0 h1:G0ACM8Z2WilWgPv3Vdzwm3V0BQu/kSmrkVtpe1fy9do=
 github.com/hashicorp/go-hclog v1.3.0/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
+github.com/hashicorp/go-hclog v1.5.0 h1:bI2ocEMgcVlz55Oj1xZNBsVi900c7II+fWDyV9o+13c=
+github.com/hashicorp/go-hclog v1.5.0/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
+github.com/hashicorp/go-hclog v1.6.2 h1:NOtoftovWkDheyUM/8JW3QMiXyxJK3uHRK7wV04nD2I=
+github.com/hashicorp/go-hclog v1.6.2/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0 h1:AKDB1HM5PWEA7i4nhcpwOrO2byshxBjXVn/J/3+z5/0=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.5 h1:i9R9JSrqIz0QVLz3sz+i3YJdT7TTSLcfLLzJi9aZTuI=

--- a/transport.go
+++ b/transport.go
@@ -117,6 +117,10 @@ func (log *HcLogToLogger) With(args ...interface{}) hclog.Logger {
 	return &HcLogToLogger{extraArgs: args}
 }
 
+func (l *HcLogToLogger) GetLevel() hclog.Level {
+    return hclog.LevelFromString("DEBUG")
+}
+
 func (log *HcLogToLogger) Named(name string) hclog.Logger {
 	return &HcLogToLogger{name: log.name + ": " + name}
 }


### PR DESCRIPTION
add support to build with hclogger 1.5.0+. I tested up to 1.6.2.

simply missing an interface function.

ignite/cosmos are using 1.5.0 as the max pin currently, causing conflicts when using libp2p raft with other modules.